### PR TITLE
Update package.json - Svelte peer dependency, add v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "!dist/**/*.spec.*"
   ],
   "peerDependencies": {
-    "svelte": "^3.54.0"
+    "svelte": "^3.54.0 || ^4.0.0"
   },
   "dependencies": {
     "js-cookie": "^3.0.1"


### PR DESCRIPTION
fixes #52 

A proposal to support the recent release of Svelte V4. 

It was checked locally on our SvelteKit project, no problems so far.

We may eventually check and add the `|global` modifier on the transitions used in [src/lib/Banner.svelte](https://github.com/beyonk-group/gdpr-cookie-consent-banner/blob/89e719d1112aa7a43da1a6bca2019fc1e9060b1e/src/lib/Banner.svelte), but IMHO, it's not necessary.

Refs:
- migration to v4: https://svelte.dev/docs/v4-migration-guide
- v4+transitions: https://svelte.dev/docs/v4-migration-guide#transitions-are-local-by-default
- https://svelte.dev/tutorial/global-transitions

