### PR TITLE
Add consent agreement status to events

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -196,20 +196,24 @@ const props = {
 
 ### Events
 
-Events are how you react to consent. Each type of consent emits an event when agreed to by the user.
+Events are how you react to consent. Each type of consent emits an event when set by the user. The agreement state is passed in the event’s details.
 
 For convenience when using Web Components - and to work around race conditions whereby events are emitted by the component prior to the handler being attached, we also emit the same events, with the prefix `consent`, on `window`.
 
 #### Svelte
 
 ```svelte
-<GdprBanner bind:this={gdprBanner} cookieName="foo" description="bar" on:analytics={initAnalytics} />
+<GdprBanner bind:this={gdprBanner} cookieName="foo" description="bar" on:analytics={handleAnalytics} />
 
 <script>
   import GdprBanner from '@beyonk/gdpr-cookie-consent-banner'
 
-  function initAnalytics () {
-    // some fathom analytics tracking code or similar
+  function handleAnalytics (event) {
+    if (event.detail.agreed) {
+      // some fathom analytics tracking code or similar
+    } else {
+      // disable any previously initialized analytics tracking code
+    }
   }
 </script>
 ```

--- a/src/lib/Banner.svelte
+++ b/src/lib/Banner.svelte
@@ -159,12 +159,10 @@
       if (choicesMerged[t]) {
         choicesMerged[t].value = agreed
       }
-      if (agreed) {
-        dispatch(t)
-        window.dispatchEvent(
-          new CustomEvent(`consent:${t}`)
-        )
-      }
+      dispatch(t, { agreed })
+      window.dispatchEvent(
+        new CustomEvent(`consent:${t}`, { detail: { agreed } })
+      )
     }
 
     shown = false

--- a/src/routes/web-component/+page.svelte
+++ b/src/routes/web-component/+page.svelte
@@ -13,7 +13,11 @@
   onMount(() => {
     for (const type of types) {
       cc.addEventListener(type, (e) => {
-        console.log(`${type} consent given`)
+        if (e.detail.agreed) {
+          console.log(`${type} consent given`)
+        } else {
+          console.log(`${type} consent rejected`)
+        }
       })
     }
   })


### PR DESCRIPTION
This PR adds the `agreed` status (`true` or `false`) to both the component and window consent events. It enables to check whether consent was given or rejected. If a user changes their mind and updates their settings after their initial decision, it’s now possible to act accordingly (and disable analytics tools without reloading the page for example).

It implies a breaking change, since the events will now be fired agreed to or not. Existing code needs to be updated by adding a check for `event.detail.agreed`. Using the same event as before is more elegant than adding a completely new event with a different naming logic in my opinion (which would be necessary since the original event simply uses its consent type as name).

Closes #63 